### PR TITLE
Renaming KeyboardNotificationDelegate to KeyboardHelperDelegate

### DIFF
--- a/Example/KeyboardHelperDemo/ViewController.swift
+++ b/Example/KeyboardHelperDemo/ViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import KeyboardHelper
 
-class ViewController: UIViewController, KeyboardNotificationDelegate {
+class ViewController: UIViewController, KeyboardHelperDelegate {
     
     fileprivate var tapGesture: UITapGestureRecognizer!
     fileprivate var keyboardHelper : KeyboardHelper?

--- a/KeyboardHelper/Classes/KeyboardHelper.swift
+++ b/KeyboardHelper/Classes/KeyboardHelper.swift
@@ -10,10 +10,11 @@ import Foundation
 import UIKit
 
 /**
-    Protocol `KeyboardNotificationDelegate` requires two functions.
+    Protocol `KeyboardHelperDelegate` requires two functions.
     Function `keyboardWillAppear` and `keyboardWillDisappear` with parameter `info` struct `KeyboardAppearanceInfo`.
 */
-public protocol KeyboardNotificationDelegate: class {
+
+public protocol KeyboardHelperDelegate: class {
     
     /**
         This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will appaear.
@@ -34,15 +35,15 @@ public protocol KeyboardNotificationDelegate: class {
 public class KeyboardHelper {
     
     /**
-        Delegate that conforms with the `KeyboardNotificationDelegate`.
+        Delegate that conforms with the `KeyboardHelperDelegate`.
     */
-    public weak var delegate: KeyboardNotificationDelegate?
+    public weak var delegate: KeyboardHelperDelegate?
     
     /**
         Initialize the `delegate` and add the two observer for `keyboardWillAppear` and `keyboardWillDisappear`.
         Observers are nessecary for tracking the `UIKeyboardWillShowNotification` and `UIKeyboardWillHideNotification`, so the function that are connectet are getting fired.
     */
-    required public init(delegate: KeyboardNotificationDelegate) {
+    required public init(delegate: KeyboardHelperDelegate) {
         self.delegate = delegate
         
         NotificationCenter.default.addObserver(self, selector: #selector(KeyboardHelper.keyboardWillAppear(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
@@ -67,3 +68,6 @@ public class KeyboardHelper {
         NotificationCenter.default.removeObserver(self)
     }
 }
+
+@available(*, deprecated, message: "KeyboardNotificationDelegate has been renamed to KeyboardHelperDelegate")
+public typealias KeyboardNotificationDelegate = KeyboardHelperDelegate

--- a/KeyboardHelperTests/Tests/KeyboardHelperTests.swift
+++ b/KeyboardHelperTests/Tests/KeyboardHelperTests.swift
@@ -9,7 +9,7 @@
 import XCTest
 @testable import KeyboardHelper
 
-class ShowSpyDelegate : KeyboardNotificationDelegate {
+class ShowSpyDelegate : KeyboardHelperDelegate {
     var kai : KeyboardAppearanceInfo?
     
     var expectation : XCTestExpectation?
@@ -29,7 +29,7 @@ class ShowSpyDelegate : KeyboardNotificationDelegate {
     }
 }
 
-class HideSpyDelegate : KeyboardNotificationDelegate {
+class HideSpyDelegate : KeyboardHelperDelegate {
     var kai : KeyboardAppearanceInfo?
     
     var expectation : XCTestExpectation?

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ pod 'KeyboardHelper', '~> 1.0'
 
 
 ## 🔧 Setup
-Implement `KeyboardNotificationDelegate` in your UIViewController.
+Implement `KeyboardHelperDelegate` in your UIViewController.
 
 ```swift
 class ViewController: UIViewController, KeyboardNotificationDelegate
@@ -51,7 +51,7 @@ func viewDidLoad() {
 	...
 }
 ```
-Implement the two methods in the `KeyboardNotificationDelegate`: 
+Implement the two methods in the `KeyboardHelperDelegate`: 
 
 ```swift
 public func keyboardWillAppear(_ info: KeyboardHelper.KeyboardAppearanceInfo)


### PR DESCRIPTION
Renaming KeyboardNotificationDelegate to KeyboardHelperDelegate. KeyboardNotificationDelegate has been deprecated. Solves issue #17 without needing a breaking change. 