### PR TITLE
Minor tweaks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ osx_image: xcode8.1
 branches:
   only:
     - master
+    - develop
 
 env:
   global:

--- a/KeyboardHelper/Classes/KeyboardAppearanceInfo.swift
+++ b/KeyboardHelper/Classes/KeyboardAppearanceInfo.swift
@@ -43,12 +43,10 @@ public struct KeyboardAppearanceInfo {
      That variable will help to keep track of which app uses the keyboard at the moment.
      If it is the current app it is true, if not it is false.
      */
+    @available(iOS 9.0, *)
     public var belongsToCurrentApp: Bool {
-        if #available(iOS 9.0, *) {
-            return (userInfo[UIKeyboardIsLocalUserInfoKey] as? Bool) ?? true
-        } else {
-            return true
-        }
+        return (userInfo[UIKeyboardIsLocalUserInfoKey] as? Bool) ?? true
+        
     }
     
     /**

--- a/KeyboardHelper/Classes/KeyboardAppearanceInfo.swift
+++ b/KeyboardHelper/Classes/KeyboardAppearanceInfo.swift
@@ -9,9 +9,7 @@
 import Foundation
 import UIKit
 
-/**
- A struct holding all keyboard view information when it's being shown or hidden.
-*/
+/// A struct holding all keyboard view information when it's being shown or hidden.
 public struct KeyboardAppearanceInfo {
     
     public let notification: Notification
@@ -22,66 +20,54 @@ public struct KeyboardAppearanceInfo {
         self.userInfo = notification.userInfo ?? [:]
     }
     
-    /**
-     Getter for the UIKeyboard frame begin infokey.
-     Return a `CGRect` or `CGRectZero`.
-    */
+    /// Getter for the UIKeyboard frame begin infokey. Returns a `CGRect` or `CGRectZero`.
     public var beginFrame: CGRect {
         return (userInfo[UIKeyboardFrameBeginUserInfoKey] as? NSValue)?.cgRectValue ?? .zero
     }
     
-    /**
-     Getter for the UIKeyboard frame end infokey.
-     Return a `CGRect` or `CGRectZero`.
-     */
+    
+    /// Getter for the UIKeyboard frame end infokey. Return a `CGRect` or `CGRectZero`.
     public var endFrame: CGRect {
         return (userInfo[UIKeyboardFrameEndUserInfoKey] as? NSValue)?.cgRectValue ?? .zero
     }
     
-    /**
-     Getter for the UIKeyboard info if the keyboard is in the current app.
-     That variable will help to keep track of which app uses the keyboard at the moment.
-     If it is the current app it is true, if not it is false.
-     */
+    
     @available(iOS 9.0, *)
+    /// Getter for the UIKeyboard info if the keyboard is in the current app.
+    /// That variable will help to keep track of which app uses the keyboard at the moment.
+    /// If it is the current app it is true, if not it is false.
     public var belongsToCurrentApp: Bool {
         return (userInfo[UIKeyboardIsLocalUserInfoKey] as? Bool) ?? true
         
     }
     
-    /**
-     Getter for the duration of the keyboard appear/disappear animation.
-     By default: `0.25`.
-     */
+    
+    /// Getter for the duration of the keyboard appear/disappear animation.
+    /// By default: `0.25`.
     public var animationDuration: Double {
         return (userInfo[UIKeyboardAnimationDurationUserInfoKey] as? NSNumber)?.doubleValue ?? 0.25
     }
-    
-    /**
-     Getter for the animation curve.
-     By default: `EaseInOut`.
-     */
+
+    /// Getter for the animation curve.
+    /// By default: `EaseInOut`.
     public var animationCurve: UIViewAnimationCurve {
         guard let value = userInfo[UIKeyboardAnimationCurveUserInfoKey] as? Int else { return .easeInOut }
         return UIViewAnimationCurve(rawValue: value) ?? .easeInOut
     }
     
-    /**
-     Getter for the animation option.
-     That variable will help to keep track of the keyboard appearence.
-     */
+    
+    /// Getter for the animation option.
+    /// That variable will help to keep track of the keyboard appearence.
     public var animationOptions: UIViewAnimationOptions {
         return UIViewAnimationOptions(rawValue: UInt(animationCurve.rawValue << 16))
     }
     
-    /**
-     Animate a `UView` while the keyboard appears and check if animation is finished.
-     If finished do completion.
-     
-     Parameters:
-        - animationBlock: Animation that should happen.
-        - completion: Function that happens after the animation is finished.
-    */
+    /// Animate a `UView` while the keyboard appears and check if animation is finished.
+    /// If finished do completion.
+    ///
+    /// Parameters:
+    ///     - animationBlock: Animation that should happen.
+    ///     - completion: Function that happens after the animation is finished.
     public func animateAlong(_ animationBlock: @escaping (() -> Void), completion: @escaping ((_ finished: Bool) -> Void) = { _ in }) {
         UIView.animate(
             withDuration: animationDuration,

--- a/KeyboardHelper/Classes/KeyboardHelper.swift
+++ b/KeyboardHelper/Classes/KeyboardHelper.swift
@@ -50,10 +50,6 @@ public class KeyboardHelper {
         NotificationCenter.default.addObserver(self, selector: #selector(KeyboardHelper.keyboardWillDisappear(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
     }
     
-    private init() {
-        delegate = nil
-    }
-    
     dynamic private func keyboardWillAppear(_ note: Notification) {
         let info = KeyboardAppearanceInfo(notification: note)
         self.delegate?.keyboardWillAppear(info)

--- a/KeyboardHelper/Classes/KeyboardHelper.swift
+++ b/KeyboardHelper/Classes/KeyboardHelper.swift
@@ -9,45 +9,45 @@
 import Foundation
 import UIKit
 
-/**
-    Protocol `KeyboardHelperDelegate` requires two functions.
-    Function `keyboardWillAppear` and `keyboardWillDisappear` with parameter `info` struct `KeyboardAppearanceInfo`.
-*/
 
+/// Protocol `KeyboardHelperDelegate` requires two functions, `keyboardWillAppear` and `keyboardWillDisappear` with parameter `info` struct `KeyboardAppearanceInfo`.
 public protocol KeyboardHelperDelegate: class {
     
-    /**
-        This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will appaear.
-        - Parameter info: Struct `KeyboardAppearanceInfo`.
-     */
+
+    /// This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will appaear.
+    ///
+    /// - Parameter info: Struct `KeyboardAppearanceInfo`.
     func keyboardWillAppear(_ info: KeyboardAppearanceInfo)
+
     
-    /**
-        This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will disappaear.
-        - Parameter info: Struct `KeyboardAppearanceInfo`.
-     */
+    /// This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will disappaear.
+    ///
+    /// - Parameter info: Struct `KeyboardAppearanceInfo`.
     func keyboardWillDisappear(_ info: KeyboardAppearanceInfo)
 }
 
-/**
-    Useful helper to keep track of keyboard changes.
-*/
+
+/// Useful helper to keep track of keyboard changes.
 public class KeyboardHelper {
     
-    /**
-        Delegate that conforms with the `KeyboardHelperDelegate`.
-    */
+    /// Delegate that conforms with the `KeyboardHelperDelegate`.
     public weak var delegate: KeyboardHelperDelegate?
     
-    /**
-        Initialize the `delegate` and add the two observer for `keyboardWillAppear` and `keyboardWillDisappear`.
-        Observers are nessecary for tracking the `UIKeyboardWillShowNotification` and `UIKeyboardWillHideNotification`, so the function that are connectet are getting fired.
-    */
+    /// Initialize the `delegate` and add the two observer for `keyboardWillAppear` and `keyboardWillDisappear`.
+    /// Observers are nessecary for tracking the `UIKeyboardWillShowNotification` and `UIKeyboardWillHideNotification`, so the function that are connectet are getting fired.
+    ///
+    /// - Parameter delegate: KeyboardHelperDelegate
     required public init(delegate: KeyboardHelperDelegate) {
         self.delegate = delegate
         
         NotificationCenter.default.addObserver(self, selector: #selector(KeyboardHelper.keyboardWillAppear(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(KeyboardHelper.keyboardWillDisappear(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+    }
+    
+    
+    /// Making sure that you can't intantiate it without a delegate
+    private init() {
+        delegate = nil
     }
     
     dynamic private func keyboardWillAppear(_ note: Notification) {

--- a/KeyboardHelperTests/Tests/KeyboardAppearanceInfoTests.swift
+++ b/KeyboardHelperTests/Tests/KeyboardAppearanceInfoTests.swift
@@ -69,9 +69,9 @@ class KeyboardAppearanceInfoTests: XCTestCase {
     }
     
     func testAnimationCurve() {
-        XCTAssertEqual(appearanceInfo.animationCurve, UIViewAnimationCurve(rawValue: 2),
+        XCTAssertEqual(appearanceInfo.animationCurve, UIViewAnimationCurve.easeOut,
             "Parsing animationCurve from keyboard appearance info failed.")
-        XCTAssertEqual(defaultsAppearanceInfo.animationCurve, UIViewAnimationCurve(rawValue: defaultsAppearanceInfo.animationCurve.rawValue),
+        XCTAssertEqual(defaultsAppearanceInfo.animationCurve, UIViewAnimationCurve.easeInOut,
             "Parsing default animationCurve from keyboard appearance info failed.")
     }
     

--- a/KeyboardHelperTests/Tests/KeyboardHelperTests.swift
+++ b/KeyboardHelperTests/Tests/KeyboardHelperTests.swift
@@ -95,7 +95,11 @@ class KeyboardHelperTests: XCTestCase {
             XCTAssertEqual(result.animationDuration, 0.25)
             XCTAssertEqual(result.beginFrame, CGRect(x: 0, y: 667, width: 375, height: 0))
             XCTAssertEqual(result.endFrame, CGRect(x: 0, y: 409, width: 375, height: 258))
-            XCTAssertEqual(result.belongsToCurrentApp, true)
+            if #available(iOS 9.0, *) {
+                XCTAssertEqual(result.belongsToCurrentApp, true)
+            } else {
+                // don't test this
+            }
 
         }
     }


### PR DESCRIPTION
This PR introduces a few minor changes:

- `belongsToCurrentApp` is marked as only available on iOS 9 and above. I think it's a more correct way of doing it like this, instead of returning a default, undocumented value for versions older than iOS 9.
- the `private init()` of `KeyboardHelper` was removed. I'm not sure why it was needed, so I removed it and all the tests pass. I'm willing to listen to reasons why it was there, and ,of course, we can add it back if it's necessary.
- updated the `testAnimationCurve` to make it less pointless

Last but not least, merging this will also increase the code coverage 😄