### PR TITLE
Create protocol extension to simulate optional methods

### DIFF
--- a/KeyboardHelper/Classes/KeyboardHelper.swift
+++ b/KeyboardHelper/Classes/KeyboardHelper.swift
@@ -12,13 +12,11 @@ import UIKit
 
 /// Protocol `KeyboardHelperDelegate` requires two functions, `keyboardWillAppear` and `keyboardWillDisappear` with parameter `info` struct `KeyboardAppearanceInfo`.
 public protocol KeyboardHelperDelegate: class {
-    
-
     /// This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will appaear.
     ///
     /// - Parameter info: Struct `KeyboardAppearanceInfo`.
     func keyboardWillAppear(_ info: KeyboardAppearanceInfo)
-
+    
     
     /// This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will disappaear.
     ///
@@ -26,6 +24,22 @@ public protocol KeyboardHelperDelegate: class {
     func keyboardWillDisappear(_ info: KeyboardAppearanceInfo)
 }
 
+extension KeyboardHelperDelegate {
+    /// This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will appaear.
+    ///
+    /// - Parameter info: Struct `KeyboardAppearanceInfo`.
+    func keyboardWillAppear(_ info: KeyboardAppearanceInfo) {
+        // default empty implementation
+    }
+    
+    
+    /// This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will disappaear.
+    ///
+    /// - Parameter info: Struct `KeyboardAppearanceInfo`.
+    func keyboardWillDisappear(_ info: KeyboardAppearanceInfo) {
+        // default empty implementation
+    }
+}
 
 /// Useful helper to keep track of keyboard changes.
 public class KeyboardHelper {

--- a/Sources/KeyboardHelper.swift
+++ b/Sources/KeyboardHelper.swift
@@ -1,1 +1,72 @@
-../KeyboardHelper/Classes/KeyboardHelper.swift
+//
+//  KeyboardHelper.swift
+//  KeyboardHelper
+//
+//  Created by Kasper Welner on 27/01/16.
+//  Copyright © 2016 Nodes. All rights reserved.
+//
+
+import Foundation
+import UIKit
+
+
+/// Protocol `KeyboardHelperDelegate` requires two functions, `keyboardWillAppear` and `keyboardWillDisappear` with parameter `info` struct `KeyboardAppearanceInfo`.
+public protocol KeyboardHelperDelegate: class {
+    
+
+    /// This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will appaear.
+    ///
+    /// - Parameter info: Struct `KeyboardAppearanceInfo`.
+    func keyboardWillAppear(_ info: KeyboardAppearanceInfo)
+
+    
+    /// This function will recongnize a change of `KeyboardAppearanceInfo` and will be fired when the keyboard will disappaear.
+    ///
+    /// - Parameter info: Struct `KeyboardAppearanceInfo`.
+    func keyboardWillDisappear(_ info: KeyboardAppearanceInfo)
+}
+
+extension KeyboardHelperDelegate {
+    
+}
+
+/// Useful helper to keep track of keyboard changes.
+public class KeyboardHelper {
+    
+    /// Delegate that conforms with the `KeyboardHelperDelegate`.
+    public weak var delegate: KeyboardHelperDelegate?
+    
+    /// Initialize the `delegate` and add the two observer for `keyboardWillAppear` and `keyboardWillDisappear`.
+    /// Observers are nessecary for tracking the `UIKeyboardWillShowNotification` and `UIKeyboardWillHideNotification`, so the function that are connectet are getting fired.
+    ///
+    /// - Parameter delegate: KeyboardHelperDelegate
+    required public init(delegate: KeyboardHelperDelegate) {
+        self.delegate = delegate
+        
+        NotificationCenter.default.addObserver(self, selector: #selector(KeyboardHelper.keyboardWillAppear(_:)), name: NSNotification.Name.UIKeyboardWillShow, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(KeyboardHelper.keyboardWillDisappear(_:)), name: NSNotification.Name.UIKeyboardWillHide, object: nil)
+    }
+    
+    
+    /// Making sure that you can't intantiate it without a delegate
+    private init() {
+        delegate = nil
+    }
+    
+    dynamic private func keyboardWillAppear(_ note: Notification) {
+        let info = KeyboardAppearanceInfo(notification: note)
+        self.delegate?.keyboardWillAppear(info)
+    }
+    
+    dynamic private func keyboardWillDisappear(_ note: Notification) {
+        let info = KeyboardAppearanceInfo(notification: note)
+        self.delegate?.keyboardWillDisappear(info)
+    }
+    
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+}
+
+@available(*, deprecated, message: "KeyboardNotificationDelegate has been renamed to KeyboardHelperDelegate")
+public typealias KeyboardNotificationDelegate = KeyboardHelperDelegate


### PR DESCRIPTION
As for comment in issue #22 the simple way to have optional methods in a `protocol` is to create a default implementation of the method in the protocol `extension`.

Tests ✅ after my change.